### PR TITLE
Feature/space gapped text

### DIFF
--- a/recumpiler/mutators.py
+++ b/recumpiler/mutators.py
@@ -538,9 +538,7 @@ def get_emoji_database():
         encoding="utf-8",
     ) as csvfile:
         df = pandas.read_csv(csvfile)
-        df.to_sql(
-            "Emoji_Sentiment_Data", emoji_database, if_exists="append", index=False
-        )
+        df.to_sql("Emoji_Sentiment_Data", emoji_database, if_exists="fail", index=False)
     return emoji_database
 
 

--- a/recumpiler/mutators.py
+++ b/recumpiler/mutators.py
@@ -1220,16 +1220,25 @@ def replace_with_random_synonym(token: str) -> str:
 
 
 @logged_mutator
-def recumpile_text(text: str) -> str:
+def recumpile_line(text: str) -> str:
     new_tokens = []
-    # TODO: preserve spacing better
-    # TODO: go sentence by sentence token by token all for sentiment analysis
     for sentence in TextBlob(text).sentences:
         new_tokens += recumpile_sentence(sentence)
-
     out_str = TreebankWordDetokenizer().detokenize(new_tokens)
     out_str = fix_punctuation_spacing(out_str)
+
     return out_str
+
+
+@logged_mutator
+def recumpile_text(text: str) -> str:
+    # TODO: preserve spacing better / Maybe use nltk tokenizers instead of a split method
+    # TODO: go sentence by sentence token by token all for sentiment analysis
+    lines = []
+
+    for line in text.split("\n"):
+        lines.append(recumpile_line(line))
+    return "\n".join(lines)
 
 
 # TODO: fuck to ck

--- a/recumpiler/mutators.py
+++ b/recumpiler/mutators.py
@@ -169,6 +169,10 @@ homofiy_percentage = 0.3
 
 back_tick_text_probability = 0.05
 
+space_gap_text_probability = 0.02
+space_gap_text_min_gap_size = 1
+space_gap_text_max_gap_size = 4
+
 
 @logged_mutator
 def num_to_word(token: str) -> str:
@@ -983,12 +987,6 @@ def recumpile_token(token: str) -> str:
         if decision(common_misspellings_probability):
             fucked_token = common_mispellings(fucked_token)
 
-        # TODO: discord format options
-        if decision(bold_text_probability):
-            fucked_token = bold_text(fucked_token)
-        elif decision(back_tick_text_probability):
-            fucked_token = back_tick_text(fucked_token)
-
         # TODO: likely also breaking the spacing between punctuation kittly 1!
         # TODO: `fucked` went to `DS` investigate
         # TODO: likely this is at fault
@@ -1030,6 +1028,22 @@ def recumpile_token(token: str) -> str:
 
         if relevant_emoji:
             fucked_tokens.append(relevant_emoji)
+
+    for i, fucked_token in enumerate(fucked_tokens):
+        if decision(space_gap_text_probability):
+            # TODO: this modification may be better placed elsewhere
+            fucked_token = space_gap_text(
+                fucked_token,
+                min_gap_size=space_gap_text_min_gap_size,
+                max_gap_size=space_gap_text_max_gap_size,
+            )
+        # TODO: discord format options
+        if decision(bold_text_probability):
+            fucked_token = bold_text(fucked_token)
+        elif decision(back_tick_text_probability):
+            fucked_token = back_tick_text(fucked_token)
+        fucked_tokens[i] = fucked_token
+
     return " ".join(fucked_tokens)
 
 
@@ -1210,6 +1224,14 @@ def custom_censoring(swear_word: str, censor_percent: float = 0.25) -> str:
             ]
         )
     return swear_word
+
+
+@logged_mutator
+def space_gap_text(token: str, min_gap_size: int = 1, max_gap_size: int = 4) -> str:
+    gap_size = random.randint(min_gap_size, max_gap_size)
+    token_ends = " " * (gap_size + 1)
+    token = token_ends + (" " * gap_size).join(token) + token_ends
+    return token
 
 
 @logged_mutator

--- a/tests/unit/test_mutators.py
+++ b/tests/unit/test_mutators.py
@@ -29,3 +29,23 @@ def test_mutate_text_blob(text):
     out_str = recumpile_text(text)
     assert isinstance(out_str, str)
     print(out_str)
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "text",
+    [
+        """
+        hello
+        there
+        """,
+        "foo\nbar",
+        "foo\n\nbar",
+        "foo\n\tbar",
+    ],
+)
+def test_mutate_text_blob_preserve_newlines(text):
+    out_str = recumpile_text(text)
+    assert isinstance(out_str, str)
+    assert "\n" in out_str
+    print(out_str)

--- a/tests/unit/test_mutators.py
+++ b/tests/unit/test_mutators.py
@@ -23,6 +23,7 @@ from recumpiler.mutators import recumpile_text
         "ksksks kkskskss kkkksksksksk kkkskskskks kkkkksksksk kksksksk sksksks ksksksks",
         "not not noot nooot not not noot not not not nothing not",
         "knot knot knot knot knot",
+        "apple " * 20,
     ],
 )
 def test_mutate_text_blob(text):


### PR DESCRIPTION
Adding mutator `space_gap_text` that creates space gapped text.

For example:
```python
>>> space_gap_text("hello")
'  h e l l o  '
```

**Note:** This also reworks how the `bold_text` and `back_tick_text` mutators are applied within `recumpile_token` to avoid breaking bolding/back tickking on a token when it is space gapped.